### PR TITLE
bugfixes: hash de anonimizacao e delete cascade de pacientes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 [![Badge Status](https://img.shields.io/badge/STATUS-AGUARDANDO-blue)](#header) [![Github Project](https://img.shields.io/badge/PROJECT%20VIEW%20KANBAM-GITHUB-green?logo=github&logoColor=white)](https://github.com/users/jtonynet/projects/6)  ![Badge GitHubActions](https://github.com/jtonynet/js-med-planner/actions/workflows/main.yml/badge.svg?branch=main)
 
-_*Novos merges não deverão ser feitos nessa branch_
+_*Branch com bugfixes, so deve ser levada em consideração caso os avaliadores desejarem_
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 [![Badge Status](https://img.shields.io/badge/STATUS-AGUARDANDO-blue)](#header) [![Github Project](https://img.shields.io/badge/PROJECT%20VIEW%20KANBAM-GITHUB-green?logo=github&logoColor=white)](https://github.com/users/jtonynet/projects/6)  ![Badge GitHubActions](https://github.com/jtonynet/js-med-planner/actions/workflows/main.yml/badge.svg?branch=main)
 
-_*Branch com bugfixes, so deve ser levada em consideração caso os avaliadores desejarem_
+_*Novos merges não deverão ser feitos nessa branch_
 
 ---
 

--- a/backend-rest/api/migrations/20240920035843-create-appointment.js
+++ b/backend-rest/api/migrations/20240920035843-create-appointment.js
@@ -16,6 +16,7 @@ module.exports = {
       },
       patientId: {
         type: Sequelize.INTEGER,
+        onDelete: 'CASCADE',
         references: {
           model: 'patients',
           key: 'id',

--- a/backend-rest/api/models/appointments.js
+++ b/backend-rest/api/models/appointments.js
@@ -35,6 +35,7 @@ module.exports = (sequelize, DataTypes) => {
           SELECT uuid, "startTime", "endTime" 
           FROM appointments 
           WHERE "doctorId" = :doctorId ${dontCheckItself}
+            AND "deletedAt" IS NULL
             AND(
               ("startTime" BETWEEN :startTime AND :endTime)
               OR("endTime" BETWEEN :startTime AND :endTime)

--- a/backend-rest/api/models/patients.js
+++ b/backend-rest/api/models/patients.js
@@ -12,7 +12,9 @@ module.exports = (sequelize, DataTypes) => {
     static associate(models) {
       patients.hasMany(models.appointments, {
         foreignKey: 'patientId',
-        as: 'appointments'
+        as: 'appointments',
+        onDelete: 'CASCADE',
+        hooks: true
       });
     }
 
@@ -164,8 +166,8 @@ module.exports = (sequelize, DataTypes) => {
     const decimalMinimun = '00.01';
     const dateOfBrazilianDiscovery = '1500-04-22';
 
-    patient.name = hashField(patient.name + patient.id);
-    patient.email = hashField((patient.email + patient.id));
+    patient.name = await hashField(patient.name);
+    patient.email = await hashField(patient.email);
     patient.phone = '000000000000000';
     patient.gender = 'unspecified';
     patient.birthDate = dateOfBrazilianDiscovery;
@@ -173,6 +175,12 @@ module.exports = (sequelize, DataTypes) => {
     patient.weight = decimalMinimun;
 
     await patient.save({ transaction: options.transaction, validate: false });
+
+    await sequelize.models.appointments.destroy({
+      where: { patientId: patient.id },
+      transaction: options.transaction,
+      individualHooks: true
+    });
   });
 
   return patients;

--- a/backend-rest/api/test/routes/appointment.test.js
+++ b/backend-rest/api/test/routes/appointment.test.js
@@ -422,8 +422,8 @@ describe('DELETE Authenticated with incorrect uuid /appointments/uuid', () => {
   });
 });
 
-describe('GET Authenticated Dont retrieve appointment deleted /patients/uuid', () => {
-  it('Should return retry appointments by deleted patient UUID', async () => {
+describe('GET Authenticated dont retrieve appointment deleted /patients/uuid', () => {
+  it('Should not return appointments for deleted patient', async () => {
     const indexToRemove = 0;
 
     await request(app)
@@ -437,7 +437,6 @@ describe('GET Authenticated Dont retrieve appointment deleted /patients/uuid', (
     });
 
     expect(deletedPatient.deletedAt).not.toBeNull();
-
 
     const response = await request(app)
       .get(`/appointments`)

--- a/backend-rest/api/test/routes/appointment.test.js
+++ b/backend-rest/api/test/routes/appointment.test.js
@@ -400,10 +400,10 @@ describe('GET Authenticated with incorrect uuid patients/uuid/appointments', () 
   });
 });
 
-describe('PATCH Authenticated with incorrect uuid patients/uuid/appointments', () => {
+describe('PATCH Authenticated with incorrect uuid appointments/uuid/appointments', () => {
   it('Should return error validate patient by incorrect UUID', async () => {
     const response = await request(app)
-      .patch('/patients/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx')
+      .patch('/appointments/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx')
       .set('Authorization', `Bearer ${bearerToken}`)
       .expect(StatusCodes.BAD_REQUEST);
 
@@ -411,13 +411,45 @@ describe('PATCH Authenticated with incorrect uuid patients/uuid/appointments', (
   });
 });
 
-describe('DELETE Authenticated with incorrect uuid /patients/uuid', () => {
+describe('DELETE Authenticated with incorrect uuid /appointments/uuid', () => {
   it('Should return error validate patient by incorrect UUID', async () => {
     const response = await request(app)
-      .delete('/patients/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx')
+      .delete('/appointments/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx')
       .set('Authorization', `Bearer ${bearerToken}`)
       .expect(StatusCodes.BAD_REQUEST);
 
     expect(response.body.message).toEqual('Request error invalid uuid');
   });
 });
+
+describe('GET Authenticated Dont retrieve appointment deleted /patients/uuid', () => {
+  it('Should return error validate patient by incorrect UUID', async () => {
+    const indexToRemove = 0;
+
+    await request(app)
+      .delete(`/patients/${patientsToCreate[indexToRemove].uuid}`)
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .expect(StatusCodes.NO_CONTENT);
+
+    const deletedPatient = await patients.findOne({
+      where: { uuid: patientsToCreate[indexToRemove].uuid },
+      paranoid: false,
+    });
+
+    expect(deletedPatient.deletedAt).not.toBeNull();
+
+
+    const response = await request(app)
+      .get(`/appointments`)
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .set('Accept', 'application.json')
+      .expect('content-type', /json/)
+      .expect(StatusCodes.OK);
+
+
+    appointmentToTest = findByUUID(response.body, appointmentsToCreate[indexToRemove].uuid)
+    expect(appointmentToTest).toBeUndefined();
+
+  });
+});
+

--- a/backend-rest/api/test/routes/appointment.test.js
+++ b/backend-rest/api/test/routes/appointment.test.js
@@ -423,7 +423,7 @@ describe('DELETE Authenticated with incorrect uuid /appointments/uuid', () => {
 });
 
 describe('GET Authenticated Dont retrieve appointment deleted /patients/uuid', () => {
-  it('Should return error validate patient by incorrect UUID', async () => {
+  it('Should return retry appointments by deleted patient UUID', async () => {
     const indexToRemove = 0;
 
     await request(app)

--- a/backend-rest/package-lock.json
+++ b/backend-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-med-planner-rest-api",
-  "version": "0.0.15",
+  "version": "0.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "js-med-planner-rest-api",
-      "version": "0.0.15",
+      "version": "0.0.18",
       "license": "ISC",
       "dependencies": {
         "bcryptjs": "^2.4.3",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,9 @@ services:
     hostname: backend-rest
     ports:
       - "3000:3000"
+    volumes:
+      - ./backend-rest:/usr/src/app
+      - /usr/src/app/node_modules
     tty: true
     networks:
       - med-planner-network


### PR DESCRIPTION
- O hash de anonimização não está sendo gerado corretamente
  - Verificar o método de hash
- Não está realizando a exclusão lógica (paranoid) dos agendamentos de pacientes removidos/anonimizados
  - Models com `paranoid` não estão realizando a exclusão lógica, utilizar o `beforeHook`
  
  Adicionado hotreload
  
__Docker  Rebuild  do projeto se faz necessário para essa nova versão__